### PR TITLE
Makes refresh_all an instance method rather than static.

### DIFF
--- a/addons/ActionIcon/ActionIcon.gd
+++ b/addons/ActionIcon/ActionIcon.gd
@@ -113,7 +113,7 @@ func refresh():
 	_refresh.call_deferred()
 
 ## Calls [method refresh] on all ActionIcon nodes in the scene tree.
-static func refresh_all():
+func refresh_all():
 	Engine.get_main_loop().call_group(GROUP_NAME, refresh.get_method())
 
 func _refresh():


### PR DESCRIPTION
Fixes error in Godot 4.3

Line 117:Cannot access non-static function "refresh" from the static function "refresh_all()".